### PR TITLE
fix: register CSI ^ as scroll down alias

### DIFF
--- a/inputhandler.go
+++ b/inputhandler.go
@@ -205,6 +205,7 @@ func NewInputHandler(
 	// CSI handlers — scroll
 	p.RegisterCsiHandler(FunctionIdentifier{Final: 'S'}, h.scrollUp)
 	p.RegisterCsiHandler(FunctionIdentifier{Final: 'T'}, h.scrollDown)
+	p.RegisterCsiHandler(FunctionIdentifier{Final: '^'}, h.scrollDown)
 	p.RegisterCsiHandler(FunctionIdentifier{Intermediates: " ", Final: '@'}, h.scrollLeft)
 	p.RegisterCsiHandler(FunctionIdentifier{Intermediates: " ", Final: 'A'}, h.scrollRight)
 	p.RegisterCsiHandler(FunctionIdentifier{Intermediates: "'", Final: '}'}, h.insertColumns)

--- a/inputhandler_csi_test.go
+++ b/inputhandler_csi_test.go
@@ -341,6 +341,16 @@ func TestScrollUpDown(t *testing.T) {
 			Input:    "AAA\x1b[2;1HBBB\x1b[1T",
 			Expected: Expectation{Row0: "", Row1: "AAA"},
 		},
+		{
+			Name:     "SD_scroll_down_caret_alias",
+			Input:    "AAA\x1b[2;1HBBB\x1b[1^",
+			Expected: Expectation{Row0: "", Row1: "AAA"},
+		},
+		{
+			Name:     "SD_scroll_down_caret_2",
+			Input:    "AAA\x1b[2;1HBBB\x1b[2^",
+			Expected: Expectation{Row0: "", Row1: ""},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

Upstream xterm.js added `CSI Ps ^` as an alias for `CSI Ps T` (scroll down) in commit `da4243c`. The Go port did not register this handler, causing the sequence to be silently ignored.

## Fix

Register `CSI ^` mapped to the existing `scrollDown` handler, matching the upstream behavior.

## Tests

Added two test cases to `TestScrollUpDown`:
- `SD_scroll_down_caret_alias` — verifies `CSI 1 ^` scrolls down by 1 (same as `CSI 1 T`)
- `SD_scroll_down_caret_2` — verifies `CSI 2 ^` scrolls down by 2

Fixes #1