### PR TITLE
fix: clear markers when Clear() is called

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -416,6 +416,8 @@ func (t *Terminal) Clear() {
 		return
 	}
 
+	buf.ClearAllMarkers()
+
 	// Copy the current cursor line to position 0.
 	buf.Lines.Set(0, buf.Lines.Get(buf.YBase+buf.Y))
 	buf.Lines.SetLength(1)

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -1187,6 +1187,34 @@ func TestTerminalClearFiresScrollEvent(t *testing.T) {
 	}
 }
 
+func TestTerminalClearDisposesMarkers(t *testing.T) {
+	t.Parallel()
+
+	term := New(WithCols(80), WithRows(24), WithScrollback(100))
+	for i := 0; i < 30; i++ {
+		term.WriteString("line\r\n")
+	}
+	m := term.AddMarker(0)
+	if m == nil {
+		t.Fatal("AddMarker returned nil")
+	}
+	if m.IsDisposed {
+		t.Fatal("marker should not be disposed before Clear()")
+	}
+	if len(term.NormalBuffer().Markers) != 1 {
+		t.Fatalf("expected 1 marker, got %d", len(term.NormalBuffer().Markers))
+	}
+
+	term.Clear()
+
+	if !m.IsDisposed {
+		t.Error("marker should be disposed after Clear()")
+	}
+	if len(term.NormalBuffer().Markers) != 0 {
+		t.Errorf("expected 0 markers after Clear(), got %d", len(term.NormalBuffer().Markers))
+	}
+}
+
 func TestTerminalAddMarker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`Terminal.Clear()` resets the buffer but does not dispose markers, leaving stale markers with invalid line references.

This adds `buf.ClearAllMarkers()` to `Terminal.Clear()` before resetting the buffer lines, matching upstream xterm.js commit [`8f2bb32c`](https://github.com/xtermjs/xterm.js/commit/8f2bb32c).

Includes a test that verifies markers are disposed and removed after `Clear()`.

Fixes #42